### PR TITLE
Fix: Show favicons of source pages in dashboard

### DIFF
--- a/resources/views/data/sources-card.blade.php
+++ b/resources/views/data/sources-card.blade.php
@@ -11,7 +11,7 @@
             <div class="px-4 sm:px-6 py-3 flex justify-between hover:bg-gray-50">
                 <div class="pr-5 text-sm leading-5 text-gray-800 truncate">
                     <div class="flex items-center">
-                        <img class="w-4 h-4 mr-3" src="https://favicons.githubusercontent.com/{{ urlencode($source->page) }}" alt="" />
+                        <img class="w-4 h-4 mr-3" src="https://www.google.com/s2/favicons?domain={{ urlencode($source->page) }}" alt="" />
 
                         <a href="{{ $source->page }}" target="_blank" class="hover:underline">
                             {{ $source->page }}


### PR DESCRIPTION
Favicons of the source pages in the analytic dashboard are not shown.

The service "favicons.githubusercontent.com" for fetching favicons is not working anymore.

> Fastly error: unknown domain: favicons.githubusercontent.com. Please check that this domain has been added to a service.
Details: cache-muc13924-MUC

Therefor I would recommend to switch to the favicon service provided by google.