### PR TITLE
Allow wildcard in exclude routes

### DIFF
--- a/config/analytics.php
+++ b/config/analytics.php
@@ -22,6 +22,7 @@ return [
 
     'exclude' => [
         '/analytics',
+        '/analytics/*'
     ],
 
     'session' => [

--- a/src/Http/Middleware/Analytics.php
+++ b/src/Http/Middleware/Analytics.php
@@ -17,8 +17,14 @@ class Analytics
 
         $response = $next($request);
 
-        if (in_array($uri, config('analytics.exclude', []))) {
-            return $response;
+        foreach (config('analytics.exclude', []) as $except) {
+            if ($except !== '/') {
+                $except = trim($except, '/');
+            }
+
+            if ($request->fullUrlIs($except) || $request->is($except)) {
+                return $response;
+            }
         }
 
         $agent = new Agent();


### PR DESCRIPTION
This change allows wildcards in the exclude routes. So it is not required anymore to add each single route.
Instead we can write it like this.

`    'exclude' => [
        '/analytics',
        '/admin',
        '/admin/*',
    ],`

The code is based on the VerifyCsrfToken middleware, which can be found here:
https://github.com/laravel/framework/blob/9.x/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
