### PR TITLE
Feat: Ignore traffic from robots

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ protected $middleware = [
 
 You can exclude certain routes from being tracked by adding them to the `exclude` array in the `analytics.php` config file.
 
+### Ignore robots
+
+You can ignore requests from robots by setting the `ignoreRobots` property in the `analytics.php` config file.
+
+
 ### Masking routes
 
 You can mask certain routes from being tracked by adding them to the `mask` array in the `analytics.php` config file. 

--- a/config/analytics.php
+++ b/config/analytics.php
@@ -24,6 +24,11 @@ return [
     ],
 
     /**
+     * Determine if traffic from robots should be tracked.
+     */
+    'ignoreRobots' => false,
+
+    /**
      * Mask.
      *
      * Mask routes so they are tracked together.

--- a/src/Http/Middleware/Analytics.php
+++ b/src/Http/Middleware/Analytics.php
@@ -17,6 +17,14 @@ class Analytics
 
         $response = $next($request);
 
+        $agent = new Agent();
+        $agent->setUserAgent($request->headers->get('user-agent'));
+        $agent->setHttpHeaders($request->headers);
+
+        if (config('analytics.ignoreRobots', false) && $agent->isRobot()) {
+            return $response;
+        }
+
         foreach (config('analytics.mask', []) as $mask) {
             $mask = trim($mask, '/');
 
@@ -35,10 +43,6 @@ class Analytics
                 return $response;
             }
         }
-
-        $agent = new Agent();
-        $agent->setUserAgent($request->headers->get('user-agent'));
-        $agent->setHttpHeaders($request->headers);
 
         PageView::create([
             'session' => $this->getSessionProvider()->get($request),

--- a/tests/Feature/AnalyticsTest.php
+++ b/tests/Feature/AnalyticsTest.php
@@ -7,6 +7,7 @@ use AndreasElia\Analytics\Models\PageView;
 use AndreasElia\Analytics\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 
 class AnalyticsTest extends TestCase
 {
@@ -66,6 +67,47 @@ class AnalyticsTest extends TestCase
         $this->assertCount(0, PageView::all());
         $this->assertDatabaseMissing('page_views', [
             'uri' => '/analytics/123',
+        ]);
+    }
+
+    /** @test */
+    public function a_page_view_from_robot_can_be_tracked_if_enabled()
+    {
+        Config::set('analytics.ignoreRobots', false);
+
+        $request = Request::create('/test', 'GET');
+        $request->headers->set('User-Agent', 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)');
+        $request->setLaravelSession($this->app['session']->driver());
+
+        (new Analytics())->handle($request, function ($req) {
+            $this->assertEquals('test', $req->path());
+            $this->assertEquals('GET', $req->method());
+        });
+
+        $this->assertCount(1, PageView::all());
+        $this->assertDatabaseHas('page_views', [
+            'uri' => '/test',
+            'device' => 'robot',
+        ]);
+    }
+
+    /** @test */
+    public function a_page_view_from_robot_is_not_tracked_if_enabled()
+    {
+        Config::set('analytics.ignoreRobots', true);
+
+        $request = Request::create('/test', 'GET');
+        $request->headers->set('User-Agent', 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)');
+        $request->setLaravelSession($this->app['session']->driver());
+
+        (new Analytics())->handle($request, function ($req) {
+            $this->assertEquals('test', $req->path());
+            $this->assertEquals('GET', $req->method());
+        });
+
+        $this->assertCount(0, PageView::all());
+        $this->assertDatabaseMissing('page_views', [
+            'uri' => '/test',
         ]);
     }
 }


### PR DESCRIPTION
This pull request enables the exclusion of robot traffic from being counted. The configuration now includes an option to enable or disable this feature. By default, all traffic, including robot traffic, is counted.