### PR TITLE
feat: Ignore traffic from specific IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ You can exclude certain routes from being tracked by adding them to the `exclude
 
 You can ignore requests from robots by setting the `ignoreRobots` property in the `analytics.php` config file.
 
+### Ignore specific IP addresses
+
+You can ignore requests from specific IP addresses by adding them to the `ignoreIps` array in the `analytics.php` config file.
 
 ### Masking routes
 

--- a/config/analytics.php
+++ b/config/analytics.php
@@ -29,12 +29,12 @@ return [
     'ignoreRobots' => false,
 
     /**
-     * Ignored IPs.
+     * Ignored IP addresses.
      *
-     * The ip addresses excluded from page view tracking.
+     * The IP addresses excluded from page view tracking.
      */
     'ignoredIPs' => [
-            //'192.168.1.1',
+        // '192.168.1.1',
     ],
 
     /**

--- a/config/analytics.php
+++ b/config/analytics.php
@@ -29,6 +29,15 @@ return [
     'ignoreRobots' => false,
 
     /**
+     * Ignored IPs.
+     *
+     * The ip addresses excluded from page view tracking.
+     */
+    'ignoredIPs' => [
+            //'192.168.1.1',
+    ],
+
+    /**
      * Mask.
      *
      * Mask routes so they are tracked together.

--- a/src/Http/Middleware/Analytics.php
+++ b/src/Http/Middleware/Analytics.php
@@ -17,6 +17,12 @@ class Analytics
 
         $response = $next($request);
 
+        $ignoredIps = config('analytics.ignoredIPs', []);
+
+        if (in_array($request->ip(), $ignoredIps)) {
+            return $response;
+        }
+
         $agent = new Agent();
         $agent->setUserAgent($request->headers->get('user-agent'));
         $agent->setHttpHeaders($request->headers);

--- a/tests/Feature/AnalyticsTest.php
+++ b/tests/Feature/AnalyticsTest.php
@@ -120,14 +120,13 @@ class AnalyticsTest extends TestCase
         $request->setLaravelSession($this->app['session']->driver());
 
         (new Analytics())->handle($request, function ($req) {
-                $this->assertEquals('test', $req->path());
-                $this->assertEquals('GET', $req->method());
-            });
+            $this->assertEquals('test', $req->path());
+            $this->assertEquals('GET', $req->method());
+        });
 
         $this->assertCount(0, PageView::all());
         $this->assertDatabaseMissing('page_views', [
             'uri' => '/test',
         ]);
     }
-
 }

--- a/tests/Feature/AnalyticsTest.php
+++ b/tests/Feature/AnalyticsTest.php
@@ -110,4 +110,24 @@ class AnalyticsTest extends TestCase
             'uri' => '/test',
         ]);
     }
+
+    /** @test */
+    public function a_page_view_from_an_excluded_ip_is_not_tracked_if_enabled()
+    {
+        Config::set('analytics.ignoredIPs', ['127.0.0.2']);
+
+        $request = Request::create('/test', 'GET', [], [], [], ['REMOTE_ADDR' => '127.0.0.2']);
+        $request->setLaravelSession($this->app['session']->driver());
+
+        (new Analytics())->handle($request, function ($req) {
+                $this->assertEquals('test', $req->path());
+                $this->assertEquals('GET', $req->method());
+            });
+
+        $this->assertCount(0, PageView::all());
+        $this->assertDatabaseMissing('page_views', [
+            'uri' => '/test',
+        ]);
+    }
+
 }


### PR DESCRIPTION
This pull request adds the possibility to exclude specific IP addresses from the analytics. This can be useful for a variety of reasons, such as excluding internal IP addresses, IP addresses of known bots, or IP addresses of users who have opted out of analytics.