### PR TITLE
Add the ability to ignore certain methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ You can ignore requests from specific IP addresses by adding them to the `ignore
 You can mask certain routes from being tracked by adding them to the `mask` array in the `analytics.php` config file. 
 This is useful if you want to track the same route with different parameters, e.g. `/users/1` and `/users/2` will be tracked as `/users/∗︎`.
 
+### Ignoring certain HTTP verbs/methods
+
+You can ignore the tracking of some methods by adding them to the `analytics.ignoreMethods` config option. For example, if you don't want to track `POST` requests, you can configure it like so:
+
+```php
+'ignoreMethods' => [
+    'POST',
+],
+```
+
 ### Changing how session_id is determined
 
 By default, `session_id` in the `page_views` table is filled with the session ID of the current request. However, in certain scenarios (for example, for API and other requests not using cookies), the session is unavailable.

--- a/config/analytics.php
+++ b/config/analytics.php
@@ -46,6 +46,15 @@ return [
         // '/users/*',
     ],
 
+    /**
+     * Ignore methods.
+     *
+     * The HTTP verbs/methods that should be excluded from page view tracking.
+     */
+    'ignoreMethods' => [
+        // 'OPTIONS', 'POST',
+    ],
+
     'session' => [
         'provider' => \AndreasElia\Analytics\RequestSessionProvider::class,
     ],

--- a/src/Http/Middleware/Analytics.php
+++ b/src/Http/Middleware/Analytics.php
@@ -17,6 +17,10 @@ class Analytics
 
         $response = $next($request);
 
+        if (in_array($request->method(), config('analytics.ignoreMethods', []))) {
+            return $response;
+        }
+
         $ignoredIps = config('analytics.ignoredIPs', []);
 
         if (in_array($request->ip(), $ignoredIps)) {

--- a/tests/Feature/AnalyticsTest.php
+++ b/tests/Feature/AnalyticsTest.php
@@ -71,6 +71,21 @@ class AnalyticsTest extends TestCase
     }
 
     /** @test */
+    public function methods_can_be_excluded()
+    {
+        Config::set('analytics.ignoreMethods', ['POST']);
+        $request = Request::create('/users', 'POST');
+        $request->setLaravelSession($this->app['session']->driver());
+
+        (new Analytics())->handle($request, fn ($req) => null);
+
+        $this->assertCount(0, PageView::all());
+        $this->assertDatabaseMissing('page_views', [
+            'uri' => '/users',
+        ]);
+    }
+
+    /** @test */
     public function a_page_view_from_robot_can_be_tracked_if_enabled()
     {
         Config::set('analytics.ignoreRobots', false);


### PR DESCRIPTION
This allows you to exclude certain methods from being tracked in page views, i.e. limiting the tracking to just GET requests.