### PR TITLE
Adding Domain Support

### DIFF
--- a/config/analytics.php
+++ b/config/analytics.php
@@ -11,6 +11,13 @@ return [
      */
     'prefix' => 'analytics',
 
+    /**
+     * Domain.
+     *
+     * The domain (optional) for the analytics dashboard.
+     */
+    'domain' => null,
+
     'middleware' => [
         'web',
     ],

--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -43,6 +43,7 @@ class AnalyticsServiceProvider extends ServiceProvider
             'namespace' => 'AndreasElia\Analytics\Http\Controllers',
             'prefix' => config('analytics.prefix'),
             'middleware' => config('analytics.middleware'),
+            'domain' => config('analytics.domain'),
         ];
     }
 


### PR DESCRIPTION
## Overview
This pull request adds the ability to isolate the analytics dashboard to a specific domain, which may be beneficial for multi-domain Laravel applications.