### PR TITLE
Put prefix in table

### DIFF
--- a/database/migrations/2020_01_01_100000_create_page_views_table.php
+++ b/database/migrations/2020_01_01_100000_create_page_views_table.php
@@ -13,7 +13,7 @@ class CreatePageViewsTable extends Migration
      */
     public function up()
     {
-        Schema::create('page_views', function (Blueprint $table) {
+        Schema::create('analytics_page_views', function (Blueprint $table) {
             $table->id();
             $table->string('uri');
             $table->string('source')->nullable();
@@ -31,6 +31,6 @@ class CreatePageViewsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('page_views');
+        Schema::dropIfExists('analytics_page_views');
     }
 }

--- a/database/migrations/2020_02_14_200000_add_session_to_page_views_table.php
+++ b/database/migrations/2020_02_14_200000_add_session_to_page_views_table.php
@@ -13,7 +13,7 @@ class AddSessionToPageViewsTable extends Migration
      */
     public function up()
     {
-        Schema::table('page_views', function (Blueprint $table) {
+        Schema::table('analytics_page_views', function (Blueprint $table) {
             $table->string('session')->nullable()->after('uri');
         });
     }
@@ -25,7 +25,7 @@ class AddSessionToPageViewsTable extends Migration
      */
     public function down()
     {
-        Schema::table('page_views', function (Blueprint $table) {
+        Schema::table('analytics_page_views', function (Blueprint $table) {
             $table->dropColumn('session');
         });
     }

--- a/database/migrations/2023_09_23_100000_add_utm_columns_to_page_views_table.php
+++ b/database/migrations/2023_09_23_100000_add_utm_columns_to_page_views_table.php
@@ -13,7 +13,7 @@ class AddUtmColumnsToPageViewsTable extends Migration
      */
     public function up()
     {
-        Schema::table('page_views', function (Blueprint $table) {
+        Schema::table('analytics_page_views', function (Blueprint $table) {
             $table->string('utm_source')->nullable()->after('device');
             $table->string('utm_medium')->nullable()->after('device');
             $table->string('utm_campaign')->nullable()->after('device');
@@ -29,7 +29,7 @@ class AddUtmColumnsToPageViewsTable extends Migration
      */
     public function down()
     {
-        Schema::table('page_views', function (Blueprint $table) {
+        Schema::table('analytics_page_views', function (Blueprint $table) {
             $table->dropColumn([
                 'utm_source',
                 'utm_medium',

--- a/database/migrations/2024_03_22_100000_add_host_to_page_views.php
+++ b/database/migrations/2024_03_22_100000_add_host_to_page_views.php
@@ -13,7 +13,7 @@ class AddHostToPageViews extends Migration
      */
     public function up()
     {
-        Schema::table('page_views', function (Blueprint $table) {
+        Schema::table('analytics_page_views', function (Blueprint $table) {
             $table->string('host')->nullable()->after('device');
         });
     }
@@ -25,7 +25,7 @@ class AddHostToPageViews extends Migration
      */
     public function down()
     {
-        Schema::table('page_views', function (Blueprint $table) {
+        Schema::table('analytics_page_views', function (Blueprint $table) {
             $table->dropColumn('host');
         });
     }

--- a/database/migrations/2024_04_18_100000_change_page_view_columns_to_nullable.php
+++ b/database/migrations/2024_04_18_100000_change_page_view_columns_to_nullable.php
@@ -13,7 +13,7 @@ class ChangePageViewColumnsToNullable extends Migration
      */
     public function up()
     {
-        Schema::table('page_views', function (Blueprint $table) {
+        Schema::table('analytics_page_views', function (Blueprint $table) {
             $table->string('country')->nullable()->change();
             $table->string('device')->nullable()->change();
         });


### PR DESCRIPTION
This PR adds a prefix to the table to distinguish it from other tables in the system, ensuring better organization and preventing potential naming conflicts.